### PR TITLE
Config to run the Project in different Port.

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -7,7 +7,7 @@ use Mix.Config
 # watchers to your application. For example, we use it
 # with brunch.io to recompile .js and .css sources.
 config :eth_price, EthPrice.Endpoint,
-  http: [port: 4000],
+  http: [port: System.get_env("PORT") || 4000],
   debug_errors: true,
   code_reloader: true,
   check_origin: false,


### PR DESCRIPTION
This let the project to be ran in a different Port. 

You can use 

`mix phoenix.server` 

to run on `port: 4000` 

or set an env to run on a different port 

`PORT=4001 mix phoenix.server` 

to run on `port: 4001`

![giphy](https://cloud.githubusercontent.com/assets/6145449/14146179/193b52c2-f66d-11e5-9ad8-99aff410d591.gif)
